### PR TITLE
Add file manager translations for Spanish and Portuguese

### DIFF
--- a/resources/lang/es/filemanager.php
+++ b/resources/lang/es/filemanager.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'root_folder_not_configurated' => 'Tu carpeta raíz no ha sido creada',
+    'root_folder_not_configurated_help' => 'Esta carpeta será tu carpeta raíz del gestor de archivos',
+    'add_your_first_folder' => 'Agrega tu primera carpeta',
+    'root_folder_name' => 'Nombre de la carpeta',
+    'elements' => '{0} Ningún elemento|[1] 1 elemento|[2,*] :value elementos',
+    'add_a_file' => 'Agregar un archivo',
+    'search' => 'Buscar',
+    'folder_already_exists' => 'Ya existe una carpeta con este nombre en el directorio actual.',
+    'folder_without_title' => 'carpeta sin título',
+    'selected' => '[1] seleccionado|[2,*] seleccionados',
+    'search_results' => 'Resultados de la búsqueda',
+    'created' => 'Creado',
+    'modified' => 'Modificado',
+    'delete_items' => 'Eliminar elementos',
+    'delete_items_warning' => '¿Estás seguro de que deseas eliminar estos elementos?',
+    'actions' => [
+        'cancel' => 'Cancelar',
+        'save' => 'Guardar',
+        'delete' => 'Eliminar',
+        'close_modal' => 'Cerrar modal',
+        'copy_url' => 'Copiar URL del archivo',
+        'url_copy_pasted' => '¡Enlace copiado al portapapeles!',
+    ],
+    'validation' => [
+        'folder_name_required' => 'El nombre de la carpeta es obligatorio',
+    ],
+];

--- a/resources/lang/pt_BR/filemanager.php
+++ b/resources/lang/pt_BR/filemanager.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'root_folder_not_configurated' => 'A sua pasta raiz não está criada',
+    'root_folder_not_configurated_help' => 'Esta pasta será a sua pasta raiz do gestor de ficheiros',
+    'add_your_first_folder' => 'Adicione a sua primeira pasta',
+    'root_folder_name' => 'Nome da pasta',
+    'elements' => '{0} Sem elementos|[1] 1 elemento|[2,*] :value elementos',
+    'add_a_file' => 'Adicionar um ficheiro',
+    'search' => 'Pesquisar',
+    'folder_already_exists' => 'Já existe uma pasta com este nome no diretório atual.',
+    'folder_without_title' => 'pasta sem título',
+    'selected' => '[1] selecionado|[2,*] selecionados',
+    'search_results' => 'Resultados da pesquisa',
+    'created' => 'Criado',
+    'modified' => 'Modificado',
+    'delete_items' => 'Eliminar itens',
+    'delete_items_warning' => 'Tem a certeza de que deseja eliminar estes itens?',
+    'actions' => [
+        'cancel' => 'Cancelar',
+        'save' => 'Guardar',
+        'delete' => 'Eliminar',
+        'close_modal' => 'Fechar modal',
+        'copy_url' => 'Copiar URL do ficheiro',
+        'url_copy_pasted' => 'Link copiado para a área de transferência!',
+    ],
+    'validation' => [
+        'folder_name_required' => 'O nome da pasta é obrigatório',
+    ],
+];

--- a/resources/lang/pt_PT/filemanager.php
+++ b/resources/lang/pt_PT/filemanager.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'root_folder_not_configurated' => 'Sua pasta raiz não foi criada',
+    'root_folder_not_configurated_help' => 'Esta pasta será a sua pasta raiz do gerenciador de arquivos',
+    'add_your_first_folder' => 'Adicione sua primeira pasta',
+    'root_folder_name' => 'Nome da pasta',
+    'elements' => '{0} Nenhum elemento|[1] 1 elemento|[2,*] :value elementos',
+    'add_a_file' => 'Adicionar um arquivo',
+    'search' => 'Pesquisar',
+    'folder_already_exists' => 'Já existe uma pasta com esse nome no diretório atual.',
+    'folder_without_title' => 'pasta sem título',
+    'selected' => '[1] selecionado|[2,*] selecionados',
+    'search_results' => 'Resultados da pesquisa',
+    'created' => 'Criado',
+    'modified' => 'Modificado',
+    'delete_items' => 'Excluir itens',
+    'delete_items_warning' => 'Tem certeza de que deseja excluir estes itens?',
+    'actions' => [
+        'cancel' => 'Cancelar',
+        'save' => 'Salvar',
+        'delete' => 'Excluir',
+        'close_modal' => 'Fechar modal',
+        'copy_url' => 'Copiar URL do arquivo',
+        'url_copy_pasted' => 'Link copiado para a área de transferência!',
+    ],
+    'validation' => [
+        'folder_name_required' => 'O nome da pasta é obrigatório',
+    ],
+];


### PR DESCRIPTION
Created new language files for Spanish (es), Portuguese (pt_PT), and Brazilian Portuguese (pt_BR).