### PR TITLE
Create new folder when clicking ousite creating folder

### DIFF
--- a/resources/views/livewire/livewire-filemanager.blade.php
+++ b/resources/views/livewire/livewire-filemanager.blade.php
@@ -93,7 +93,7 @@
                     x-on:dblclick.self="$wire.createNewFolder()"
                     class="p-2 pb-10 min-h-[500px] select-none overflow-y-auto flex relative flex-wrap content-start">
                         @if ($isCreatingNewFolder)
-                            <div class="cursor-pointer mb-4 max-w-[137px] min-w-[137px] max-h-[137px] min-h-[137px] items-start p-2 mx-1 text-center">
+                            <div class="cursor-pointer mb-4 max-w-[137px] min-w-[137px] max-h-[137px] min-h-[137px] items-start p-2 mx-1 text-center" @click.outside="$wire.saveNewFolder">
                                 <x-livewire-filemanager::icons.folder class="mx-auto w-16 h-16 mb-2" />
 
                                 <input type="text" id="new-folder-name" wire:model="newFolderName" wire:keydown.enter="saveNewFolder" class="text-center w-full rounded py-0.5 px-1 text-sm dark:bg-slate-800 dark:text-slate-200">


### PR DESCRIPTION
This commit adds the "click outside" behavior when creating a new folder. So when the user create a new folder, set the name and then click outside, the folder will be created.

closes #9 