### PR TITLE
RTL style fixes

### DIFF
--- a/resources/views/components/form/text-input.blade.php
+++ b/resources/views/components/form/text-input.blade.php
@@ -1,1 +1,1 @@
-<input {{ $attributes->merge(['class' => 'rounded border border-zinc-300 w-full py-2 px-3 zinc-500 leading-tight focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:mr-2 dark:bg-zinc-700 dark:border-zinc-600 dark:text-zinc-300']) }}>
+<input {{ $attributes->merge(['class' => 'rounded border border-zinc-300 w-full py-2 px-3 zinc-500 leading-tight focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:me-2 dark:bg-zinc-700 dark:border-zinc-600 dark:text-zinc-300']) }}>

--- a/resources/views/components/icons/plus.blade.php
+++ b/resources/views/components/icons/plus.blade.php
@@ -1,3 +1,3 @@
-<svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+<svg class="-ms-0.5 me-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
     <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z"></path>
 </svg>

--- a/resources/views/components/livewire-filemanager-modal.blade.php
+++ b/resources/views/components/livewire-filemanager-modal.blade.php
@@ -5,7 +5,7 @@
 
     <div class="relative min-h-screen flex items-center justify-center p-4">
         <div x-dialog:panel x-transition class="relative max-w-xl w-full bg-white rounded-xl shadow-lg overflow-y-auto dark:bg-zinc-800">
-            <div class="absolute top-0 right-0 pt-4 pr-4">
+            <div class="absolute top-0 end-0 pt-4 pe-4">
                 <button type="button" @click="$dialog.close()" class="bg-gray-50 rounded-lg p-2 text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:bg-zinc-700 dark:text-zinc-200">
                     <span class="sr-only">{{ __('livewire-filemanager::filemanager.actions.close_modal') }}</span>
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
@@ -22,7 +22,7 @@
                 </div>
             </div>
 
-            <div class="p-4 flex justify-end space-x-2 bg-gray-50 dark:bg-zinc-900/30">
+            <div class="p-4 flex justify-end gap-x-2 bg-gray-50 dark:bg-zinc-900/30">
                 <x-livewire-filemanager::buttons.secondary type="button" x-on:click="$dialog.close()">
                     {{ __('livewire-filemanager::filemanager.actions.cancel') }}
                 </x-livewire-filemanager::buttons.secondary>

--- a/resources/views/livewire/livewire-filemanager.blade.php
+++ b/resources/views/livewire/livewire-filemanager.blade.php
@@ -19,7 +19,7 @@
                     <div>
                         <input type="file" wire:model.live="files" name="files" id="fileInput" multiple style="display: none;">
 
-                        <button class="border rounded p-1.5 px-2 md:px-4 flex text-sm items-center space-x-4 bg-zinc-100 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300" @click="Livewire.dispatch('reset-media', { media_id: null })" onclick="document.getElementById('fileInput').click();">
+                        <button class="border rounded p-1.5 px-2 md:px-4 flex text-sm items-center gap-x-4 bg-zinc-100 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300" @click="Livewire.dispatch('reset-media', { media_id: null })" onclick="document.getElementById('fileInput').click();">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
                             </svg>
@@ -29,7 +29,7 @@
                     </div>
 
                     <div class="flex space-x-4 items-center">
-                        <div class="flex items-center space-x-2 max-h-[25px]">
+                        <div class="flex items-center gap-x-2 max-h-[25px]">
                             @if((count($selectedFolders) + count($selectedFiles)) > 0)
                                 <div>
                                     <button @click="Livewire.dispatch('reset-media', { media_id: null })" class="border rounded p-1.5 border-red-600 text-white bg-red-500 dark:bg-red-600" wire:click="deleteItems">
@@ -62,7 +62,7 @@
                                 </button>
                             </div>
 
-                            <input wire:model.live="search" @click="Livewire.dispatch('reset-media', { media_id: null })" class="rounded border border-zinc-300 w-full py-2 px-3 zinc-500 leading-tight focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:mr-2 dark:bg-zinc-700 dark:border-zinc-600 dark:text-zinc-500" type="search" placeholder="{{ __('livewire-filemanager::filemanager.search') }}...">
+                            <input wire:model.live="search" @click="Livewire.dispatch('reset-media', { media_id: null })" class="rounded border border-zinc-300 w-full py-2 px-3 zinc-500 leading-tight focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:me-2 dark:bg-zinc-700 dark:border-zinc-600 dark:text-zinc-500" type="search" placeholder="{{ __('livewire-filemanager::filemanager.search') }}...">
                         </div>
                     </div>
                 </div>
@@ -126,7 +126,7 @@
 
                 <nav class="select-none border-t text-sm px-4 sm:px-4 py-1.5 flex items-center border-zinc-300 dark:border-zinc-700 text-black dark:text-zinc-300">
                     @foreach ($breadcrumb as $index => $folder)
-                        <span class="cursor-pointer flex space-x-1 items-center" @click="Livewire.dispatch('reset-media', { media_id: null })" wire:click.prevent="navigateToBreadcrumb({{ $index }})">
+                        <span class="cursor-pointer flex gap-x-1 items-center" @click="Livewire.dispatch('reset-media', { media_id: null })" wire:click.prevent="navigateToBreadcrumb({{ $index }})">
                             <x-livewire-filemanager::icons.folder class="w-5 h-5" /> <span>{{ $folder->name }}</span>
                         </span>
 

--- a/resources/views/livewire/livewire-filemanager.blade.php
+++ b/resources/views/livewire/livewire-filemanager.blade.php
@@ -45,7 +45,7 @@
                             @if ($this->currentFolder->id !== 1)
                                 <div>
                                     <button class="border rounded p-1.5 border-zinc-300 dark:border-zinc-600 dark:text-zinc-500" @click="Livewire.dispatch('reset-media', { media_id: null })" wire:click="navigateToParent">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 rtl:rotate-y-180">
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
                                         </svg>
                                     </button>

--- a/resources/views/livewire/media-panel.blade.php
+++ b/resources/views/livewire/media-panel.blade.php
@@ -2,9 +2,9 @@
     x-on:load-media.window="show = true"
     x-on:reset-media.window="show = false"
     :class="{ 'block animate-[slideIn_0.5s_forwards]': show, 'hidden animate-[slideOut_0.5s_forwards]': !show }"
-    class="absolute w-screen max-w-md top-0 right-0 bottom-0">
+    class="absolute w-screen max-w-md top-0 end-0 bottom-0">
         <div class="bg-white border-l min-h-full shadow-lg border-zinc-300 p-4 relative dark:bg-zinc-900 dark:border-zinc-800">
-            <div class="ml-3 absolute right-4 top-4 flex h-7 items-center">
+            <div class="ms-3 absolute end-4 top-4 flex h-7 items-center">
                 <button @click="Livewire.dispatch('reset-media', { media_id: null })" type="button" class="relative rounded-md border text-zinc-500 border-zinc-300 p-1 focus:outline-none focus:ring-2 focus:ring-white dark:border-zinc-600 dark:text-zinc-500" @click="open = false">
                     <span class="absolute -inset-2.5"></span>
                     <span class="sr-only">Close panel</span>
@@ -47,7 +47,7 @@
                 </div>
 
                 <div class="pb-4 pt-4 relative">
-                    <div class="flex space-x-4 text-sm">
+                    <div class="flex gap-x-4 text-sm">
                         <a href="{{ $media->getUrl() }}" download class="group border rounded p-1.5 inline-flex items-center font-medium text-blue-500 group-hover:text-blue-900 dark:text-blue-300 dark:group-hover:text-blue-400">
                             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
@@ -59,7 +59,7 @@
                                 <path d="M12.232 4.232a2.5 2.5 0 013.536 3.536l-1.225 1.224a.75.75 0 001.061 1.06l1.224-1.224a4 4 0 00-5.656-5.656l-3 3a4 4 0 00.225 5.865.75.75 0 00.977-1.138 2.5 2.5 0 01-.142-3.667l3-3z"></path>
                                 <path d="M11.603 7.963a.75.75 0 00-.977 1.138 2.5 2.5 0 01.142 3.667l-3 3a2.5 2.5 0 01-3.536-3.536l1.225-1.224a.75.75 0 00-1.061-1.06l-1.224 1.224a4 4 0 105.656 5.656l3-3a4 4 0 00-.225-5.865z"></path>
                             </svg>
-                            <span class="ml-2">{{ __('livewire-filemanager::filemanager.actions.copy_url') }}</span>
+                            <span class="ms-2">{{ __('livewire-filemanager::filemanager.actions.copy_url') }}</span>
                         </button>
                     </div>
 


### PR DESCRIPTION
Many RTL style fixes.
use `gap-x` instead of `space-x`, use `start` & `end` instead of `right`, `left`.