### PR TITLE
Add folder exists UI feedback

### DIFF
--- a/resources/views/livewire/livewire-filemanager.blade.php
+++ b/resources/views/livewire/livewire-filemanager.blade.php
@@ -96,6 +96,12 @@
                                 <x-livewire-filemanager::icons.folder class="mx-auto w-16 h-16 mb-2" />
 
                                 <input type="text" id="new-folder-name" wire:model="newFolderName" wire:keydown.enter="saveNewFolder" class="text-center w-full rounded py-0.5 px-1 text-sm dark:bg-zinc-800 dark:text-zinc-200">
+
+                                @error('newFolderName')
+                                <span class="text-left text-xs leading-none text-red-500 overflow-hidden text-ellipsis line-clamp-4">
+                                    {{ $message }}
+                                </span>
+                                @enderror
                             </div>
                         @endif
 


### PR DESCRIPTION
Add an error message that shows to the user that a folder already exists with the same name in the same directory