### PR TITLE
Fix/acl root folder

### DIFF
--- a/src/Livewire/LivewireFilemanagerComponent.php
+++ b/src/Livewire/LivewireFilemanagerComponent.php
@@ -41,7 +41,7 @@ class LivewireFilemanagerComponent extends Component
     public function mount()
     {
         if (! session('currentFolderId')) {
-            session(['currentFolderId' => 1]);
+            session(['currentFolderId' => Folder::whereNotNull('parent_id')->first() ? Folder::whereNotNull('parent_id')->first()->id : null]);
         }
 
         $currentFolderId = session('currentFolderId');
@@ -84,7 +84,7 @@ class LivewireFilemanagerComponent extends Component
     public function loadFolders()
     {
         if ($this->search != '') {
-            $this->folders = Folder::where('id', '!=', 1)->where('name', 'like', '%'.$this->search.'%')->get();
+            $this->folders = Folder::whereNotNull('parent_id')->where('name', 'like', '%'.$this->search.'%')->get();
             $this->searchedFiles = Media::where('collection_name', 'medialibrary')->where('name', 'like', '%'.$this->search.'%')->get();
         } else {
             $this->folders = $this->currentFolder->fresh()->children;

--- a/src/Livewire/LivewireFilemanagerComponent.php
+++ b/src/Livewire/LivewireFilemanagerComponent.php
@@ -115,7 +115,7 @@ class LivewireFilemanagerComponent extends Component
 
     public function updatedSearch()
     {
-        $this->currentFolder = Folder::find(1);
+        $this->currentFolder = Folder::whereNull('parent_id')->first();
 
         session(['currentFolderId' => $this->currentFolder->id]);
 
@@ -163,7 +163,7 @@ class LivewireFilemanagerComponent extends Component
             ],
         ]);
 
-        $newFolder = new Folder;
+        $newFolder = new Folder();
 
         $newFolder->name = trim($this->newFolderName) ?: __('livewire-filemanager::filemanager.folder_without_title');
         $newFolder->slug = Str::slug(trim($this->newFolderName) ?: __('livewire-filemanager::filemanager.folder_without_title'));

--- a/src/Models/Folder.php
+++ b/src/Models/Folder.php
@@ -41,12 +41,12 @@ class Folder extends Model implements HasMedia
 
     public function isHomeFolder(): bool
     {
-        return $this->id === 1;
+        return is_null($this->parent_id);
     }
 
     public function parentWithoutRootFolder(): BelongsTo
     {
-        return $this->belongsTo(Folder::class, 'parent_id')->where('id', '!=', 1);
+        return $this->belongsTo(Folder::class, 'parent_id')->whereNotNull('parent_id');
     }
 
     public function parent(): BelongsTo


### PR DESCRIPTION
This PR fixes a bug for the root folder when using ACL. Because the id of the root folder was hardcoded, the folder couldn't be accessed by a user where it's root folder wasn't the first one with the ID of 1 in the database.