### PR TITLE
Tenant aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ A simple, friendly, and practical file manager designed specifically for Laravel
 
 Watch the presentation of the package here: [Laravel Switzerland Meetup](https://www.youtube.com/watch?v=lgk_1AtukfM)
 
+## Additions in this fork (lambertbeekhuis/livewire-filemanager)
+First, use the Livewire-compenent directly in your blade file, instead of using the x-livewire-filemanager tag. This way you can pass parameters to the component.
+
+<livewire:livewire-filemanager tenant_id="{{session('tenant')}}" />
+
+Second, I added the option for a tenant-id/team-id the folders-table. So the filemanager can be used in a multi-tenant application. The tenant_id is stored in the session, so it is available in the blade file.
+
+I did this not by a global config, but by the option to add the tenant_id as a parameter in the livewire-component.
+
+In addition, also the user_id can be added directly to the livewire-component. This way, the filemanager can be used in a multi-user application.
+
+<livewire:livewire-filemanager tenant_id="{{session('tenant')}}" user_id="{{Auth::id()}}" />
+
+In addition, I solved some bugs related to using the filemanager with ACL or multi-tenant.
+
 ## Project requirements
 
 - PHP 8.2.0 or greater required

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "livewire-filemanager/filemanager",
+    "name": "lambertbeekhuis/filemanager",
     "description": "A simple, friendly and practical Livewire filemanager for your applications",
     "homepage": "https://github.com/livewire-filemanager/filemanager",
     "keywords": [

--- a/config/livewire-fileuploader.stub
+++ b/config/livewire-fileuploader.stub
@@ -9,4 +9,7 @@ return [
     |
     */
     'acl_enabled' => false,
+    'tenant_enabled' => false,
+    'tenant_model' => '\App\Models\Tenant::class',
+    'tenant_column_id' => 'tenant_id',
 ];

--- a/database/migrations/include_tenant_id_in_folders.stub
+++ b/database/migrations/include_tenant_id_in_folders.stub
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+       if (config('livewire-fileuploader.acl_enabled')) {
+           Schema::table('folders', function (Blueprint $table) {
+               if (!Schema::hasColumn('folders', config('livewire-fileuploader.tenant_id_column', 'tenant_id'))) {
+                   $table->foreignIdFor(config('livewire-fileuploader.tenant_model', '\App\Models\Tenant::class'), config('livewire-fileuploader.tenant_id_column', 'tenant_id'))
+                       ->after('user_id')
+                       ->nullable()
+                       ->nullOnDelete();
+               }
+           });
+       }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (config('livewire-fileuploader.acl_enabled')) {
+            Schema::table('folders', function (Blueprint $table) {
+                $table->dropForeign([config('livewire-fileuploader.tenant_id_column', 'tenant_id')]);
+                $table->dropColumn(config('livewire-fileuploader.tenant_id_column', 'tenant_id'));
+            });
+        }
+    }
+};

--- a/src/FilemanagerServiceProvider.php
+++ b/src/FilemanagerServiceProvider.php
@@ -44,6 +44,7 @@ class FilemanagerServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__ . '/../database/migrations/create_folders_table.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_folders_table.php'),
                 __DIR__ . '/../database/migrations/include_user_id_column_in_folders_table.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_include_user_id_column_in_folders_table.php'),
+                __DIR__ . '/../database/migrations/include_tenant_id_in_folders_table.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_include_tenant_id_in_folders_table.php'),
             ], 'livewire-fileuploader-migrations');
 
             $this->publishes([

--- a/src/Models/Folder.php
+++ b/src/Models/Folder.php
@@ -18,6 +18,8 @@ class Folder extends Model implements HasMedia
 
     protected $fillable = [
         'parent_id',
+        'user_id',
+        'tenant_id',
         'name',
         'slug',
     ];
@@ -71,12 +73,12 @@ class Folder extends Model implements HasMedia
 
     public function isHomeFolder(): bool
     {
-        return $this->id === 1;
+        return is_null($this->parent_id);
     }
 
     public function parentWithoutRootFolder(): BelongsTo
     {
-        return $this->belongsTo(Folder::class, 'parent_id')->where('id', '!=', 1);
+        return $this->belongsTo(Folder::class, 'parent_id')->whereNotNull('parent_id');
     }
 
     public function parent(): BelongsTo


### PR DESCRIPTION
Hi,

See in the README.md, I added changes to:

Make the livewire-filemaker component user and tenant-aware

Now you can for example have filemanager for a specific user, or for a specfic tenant

<livewire:livewire-filemanager tenant_id="{{session('tenant')}}" user_id="{{Auth::id()}}" />





