### PR TITLE
Added Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         php: [8.3, 8.2]
         laravel: [10.*, 11.*, 12.*, 13.*]
-        dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: ^8.0
@@ -24,7 +23,7 @@ jobs:
           - php: 8.2
             laravel: 13.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -40,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-scripts
+          composer update --prefer-stable --prefer-dist --no-interaction --no-scripts
 
       - name: Execute tests
         run: composer test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.2]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -18,6 +18,11 @@ jobs:
             testbench: ^9.0
           - laravel: 12.*
             testbench: ^10.0
+          - laravel: 13.*
+            testbench: ^11.0
+        exclude:
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,9 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-scripts
+        run: |
+          composer require "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-scripts
 
       - name: Execute tests
         run: composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `livewire-filemanager/filemanager` will be documented in this file.
 
+## [1.1.0] - 2026-03-18
+
+### Added
+
+- Laravel 13 support
+- PHPUnit 12 support
+- Orchestra Testbench 11 support
+
+### Changed
+
+- Migrated model event registration from `boot()` to `booted()` for Laravel 13 compatibility (backward-compatible with Laravel 10/11/12)
+- Updated CI matrix to include Laravel 13 (PHP 8.3+ required for Laravel 13)
+
 ## [1.0.0] - 2024-11-23
 
 ### Breaking Changes ⚠️

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.2|^8.3",
-        "illuminate/database": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/view": "^10|^11|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/view": "^10.0|^11.0|^12.0|^13.0",
         "livewire/livewire": "^3.5.4|^4.0",
         "spatie/laravel-medialibrary": "^10.15|^11.5.4"
     },
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.16",
-        "orchestra/testbench": "^8.23.2|^10.0",
-        "phpunit/phpunit": "^10.5.20|^11.0"
+        "orchestra/testbench": "^8.23.2|^10.0|^11.0",
+        "phpunit/phpunit": "^10.5.20|^11.0|^12.5.12"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.16",
-        "orchestra/testbench": "^8.23.2|^10.0|^11.0",
+        "orchestra/testbench": "^8.23.2|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^10.5.20|^11.0|^12.5.12"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage/>
   <testsuites>
     <testsuite name="Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage/>
   <testsuites>
     <testsuite name="Test Suite">

--- a/src/Models/Folder.php
+++ b/src/Models/Folder.php
@@ -25,10 +25,8 @@ class Folder extends Model implements HasMedia
 
     public $registerMediaConversionsUsingModelInstance = true;
 
-    protected static function boot(): void
+    protected static function booted(): void
     {
-        parent::boot();
-
         static::deleting(function ($folder) {
             if ($folder->isHomeFolder()) {
                 return false;
@@ -46,10 +44,7 @@ class Folder extends Model implements HasMedia
                 $folder->user_id = $user->id;
             }
         });
-    }
 
-    protected static function booted()
-    {
         static::addGlobalScope('user_id', function (Builder $builder) {
             if (! config('livewire-filemanager.acl_enabled')) {
                 return;

--- a/tests/Feature/DragDropTest.php
+++ b/tests/Feature/DragDropTest.php
@@ -49,8 +49,7 @@ class DragDropTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function can_move_single_folder_to_another_folder()
+    public function test_can_move_single_folder_to_another_folder()
     {
         Livewire::test(LivewireFilemanagerComponent::class)
             ->call('moveItemsToFolder', $this->targetFolder->id, [$this->sourceFolder->id], [])
@@ -60,8 +59,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->targetFolder->id, $this->sourceFolder->fresh()->parent_id);
     }
 
-    /** @test */
-    public function can_move_multiple_folders_to_another_folder()
+    public function test_can_move_multiple_folders_to_another_folder()
     {
         $anotherFolder = Folder::create([
             'name' => 'Another Folder',
@@ -77,8 +75,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->targetFolder->id, $anotherFolder->fresh()->parent_id);
     }
 
-    /** @test */
-    public function can_move_file_to_folder()
+    public function test_can_move_file_to_folder()
     {
         $file = UploadedFile::fake()->image('test.jpg');
         $media = $this->sourceFolder->addMedia($file->getRealPath())
@@ -93,8 +90,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->targetFolder->id, $media->fresh()->model_id);
     }
 
-    /** @test */
-    public function can_move_multiple_files_to_folder()
+    public function test_can_move_multiple_files_to_folder()
     {
         $file1 = UploadedFile::fake()->image('test1.jpg');
         $media1 = $this->sourceFolder->addMedia($file1->getRealPath())
@@ -115,8 +111,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->targetFolder->id, $media2->fresh()->model_id);
     }
 
-    /** @test */
-    public function can_move_mixed_items_to_folder()
+    public function test_can_move_mixed_items_to_folder()
     {
         $file = UploadedFile::fake()->image('test.jpg');
         $media = $this->sourceFolder->addMedia($file->getRealPath())
@@ -137,8 +132,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->targetFolder->id, $media->fresh()->model_id);
     }
 
-    /** @test */
-    public function cannot_move_folder_to_itself()
+    public function test_cannot_move_folder_to_itself()
     {
         Livewire::test(LivewireFilemanagerComponent::class)
             ->call('moveItemsToFolder', $this->sourceFolder->id, [$this->sourceFolder->id], []);
@@ -146,8 +140,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->rootFolder->id, $this->sourceFolder->fresh()->parent_id);
     }
 
-    /** @test */
-    public function cannot_move_parent_folder_to_its_child()
+    public function test_cannot_move_parent_folder_to_its_child()
     {
         Livewire::test(LivewireFilemanagerComponent::class)
             ->call('moveItemsToFolder', $this->nestedFolder->id, [$this->sourceFolder->id], []);
@@ -155,8 +148,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->rootFolder->id, $this->sourceFolder->fresh()->parent_id);
     }
 
-    /** @test */
-    public function moving_folder_also_moves_its_children()
+    public function test_moving_folder_also_moves_its_children()
     {
         Livewire::test(LivewireFilemanagerComponent::class)
             ->call('moveItemsToFolder', $this->targetFolder->id, [$this->sourceFolder->id], []);
@@ -165,8 +157,7 @@ class DragDropTest extends TestCase
         $this->assertEquals($this->sourceFolder->id, $this->nestedFolder->fresh()->parent_id);
     }
 
-    /** @test */
-    public function selection_is_cleared_after_move()
+    public function test_selection_is_cleared_after_move()
     {
         $component = Livewire::test(LivewireFilemanagerComponent::class)
             ->set('selectedFolders', [$this->sourceFolder->id])
@@ -177,8 +168,7 @@ class DragDropTest extends TestCase
             ->assertSet('selectedFiles', []);
     }
 
-    /** @test */
-    public function move_to_non_existent_folder_does_nothing()
+    public function test_move_to_non_existent_folder_does_nothing()
     {
         $originalParentId = $this->sourceFolder->parent_id;
 

--- a/tests/Feature/FilemanagerGlobalScopeTest.php
+++ b/tests/Feature/FilemanagerGlobalScopeTest.php
@@ -18,13 +18,9 @@ class FilemanagerGlobalScopeTest extends TestCase
     }
 
     /**
-     * User can only view the folders that they own.
-     *
      * @group filemanager
-     *
-     * @test
      */
-    public function user_can_only_view_folders_that_they_own()
+    public function test_user_can_only_view_folders_that_they_own()
     {
         $this->actingAs($this->testUser);
 
@@ -43,13 +39,9 @@ class FilemanagerGlobalScopeTest extends TestCase
     }
 
     /**
-     * User can only view the files that they own.
-     *
      * @group filemanager
-     *
-     * @test
      */
-    public function user_can_only_view_files_that_they_own()
+    public function test_user_can_only_view_files_that_they_own()
     {
         $this->actingAs($this->testUser);
 

--- a/tests/Feature/FilemanagerTest.php
+++ b/tests/Feature/FilemanagerTest.php
@@ -9,26 +9,18 @@ use LivewireFilemanager\Filemanager\Tests\TestCase;
 class FilemanagerTest extends TestCase
 {
     /**
-     * The component can be rendered.
-     *
      * @group filemanager
-     *
-     * @test
      */
-    public function the_livewire_filemanager_component_can_be_rendered()
+    public function test_the_livewire_filemanager_component_can_be_rendered()
     {
         Livewire::test(LivewireFilemanagerComponent::class)
             ->assertStatus(200);
     }
 
     /**
-     * If the database doesn't have a root folder inside the database, the component will show a message.
-     *
      * @group filemanager
-     *
-     * @test
      */
-    public function no_folder_for_starting_point()
+    public function test_no_folder_for_starting_point()
     {
         Livewire::test(LivewireFilemanagerComponent::class)
             ->assertSee(__('livewire-filemanager::filemanager.root_folder_not_configurated'))

--- a/tests/Models/TestFolderModel.php
+++ b/tests/Models/TestFolderModel.php
@@ -22,10 +22,8 @@ class TestFolderModel extends Model
 
     public $registerMediaConversionsUsingModelInstance = true;
 
-    protected static function boot(): void
+    protected static function booted(): void
     {
-        parent::boot();
-
         static::deleting(function ($folder) {
             if ($folder->isHomeFolder()) {
                 return false;
@@ -43,10 +41,7 @@ class TestFolderModel extends Model
                 $folder->user_id = $user->id;
             }
         });
-    }
 
-    protected static function booted()
-    {
         static::addGlobalScope('user_id', function (Builder $builder) {
             if (! config('livewire-filemanager.acl_enabled')) {
                 return;

--- a/tests/Models/TestMediaModel.php
+++ b/tests/Models/TestMediaModel.php
@@ -34,10 +34,8 @@ class TestMediaModel extends Model
 
     public $registerMediaConversionsUsingModelInstance = true;
 
-    protected static function boot(): void
+    protected static function booted(): void
     {
-        parent::boot();
-
         static::deleting(function ($folder) {
             if ($folder->isHomeFolder()) {
                 return false;
@@ -55,10 +53,7 @@ class TestMediaModel extends Model
                 $folder->user_id = $user->id;
             }
         });
-    }
 
-    protected static function booted()
-    {
         static::addGlobalScope('user_id', function (Builder $builder) {
             if (! config('livewire-filemanager.acl_enabled')) {
                 return;


### PR DESCRIPTION
This PR add support for Laravel 13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 13 (PHP 8.3+), PHPUnit 12 and Orchestra Testbench 11

* **Chores**
  * Updated CI matrix and dependency constraints to include Laravel 13 and related tooling
  * Updated test runner configuration to latest PHPUnit schema

* **Compatibility**
  * Adjusted model lifecycle registration for Laravel 13 compatibility (backward-compatible with 10–12)

* **Tests**
  * Modernized test suite naming and structure (no behavior changes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->